### PR TITLE
Fixing various issues in macros

### DIFF
--- a/gdb_macros_for_ruby
+++ b/gdb_macros_for_ruby
@@ -16,7 +16,7 @@ document rb_bt
 end
 
 define rb_raise
-  call rb_raise((int)rb_eException, "Forced exception from GDB to get a valid ruby stack trace")
+  call rb_raise(rb_eException, "Forced exception from GDB to get a valid ruby stack trace")
 end
 document rb_raise
   Raise a Ruby exception from gdb.


### PR DESCRIPTION
I fixed various issues related to 64 bits : 

some pointer were casted to int, which reduce the precision : 

   (gdb) p backtrace(-1)
   $1 = 140485347118240
   (gdb) p (int)backtrace(-1)
   $2 = 1261833136

And some were using offset dependent on the architecture to access members, instead of using higher level construct like  ((struct RArray) *$ary).len instead  *($ary+8) 
( +8 was the size of the RBasic structure on 32 bits, but on 64 bits, the size is doubled, and it should be +16 ). 
