### PR TITLE
Fix rb_locals by using reval instead of eval

### DIFF
--- a/gdb_macros_for_ruby
+++ b/gdb_macros_for_ruby
@@ -68,7 +68,7 @@ document rb_object_counts
 end
 
 define rb_locals
-  eval "local_variables.map{|x| puts '%s = %s' % [x, eval(x)]}; nil"
+  reval "local_variables.each{|x| puts '%s = %s' % [x, eval(x.to_s)]};nil"
 end
 document rb_locals
   Print local variables and their values.


### PR DESCRIPTION
The current implementation of rb_locals fails with `Unrecognized format specifier '[' in printf`

1.This is because the `eval` macro was renamed to `reval` in an [earlier commit](d0b5b7b34c694b2e5f6c8c9ef9db1fff1ff937f2) but rb_locals continued to use `eval`.
2. The ruby `eval` inside the `map` does not take a symbol. It fails with a `TypeError: no implicit conversion of Symbol into String` when passed a symbol.

In addition, I also changed the `.map` to a `.each` since the intent is to loop and not to transform.
